### PR TITLE
72 툴팁의 컨텐츠가 다른 요소에 의해 가려지는 버그 픽스

### DIFF
--- a/src/components/badge/ErrorBadge.stories.tsx
+++ b/src/components/badge/ErrorBadge.stories.tsx
@@ -7,12 +7,6 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  // argTypes: {
-  //   errorText: {
-  //     control: 'select',
-  //     options: ['sd', 'esx'],
-  //   },
-  // },
 } satisfies Meta<typeof ErrorBadge>;
 
 export default meta;

--- a/src/components/badge/champion/ChampionBadge10.stories.tsx
+++ b/src/components/badge/champion/ChampionBadge10.stories.tsx
@@ -1,7 +1,9 @@
-import type { Meta } from '@storybook/react';
-import { ChampionBadge10 } from './ChampionBadge10';
+import type { Meta, StoryFn } from '@storybook/react';
+import { ChampionBadge10, ChampionBadge10Props } from './ChampionBadge10';
 import { LanguageType, Season } from '../../../types';
 import { champions_season_10 } from '../../../_generated/season_10/champions_season_10';
+import { ComponentProps } from 'react';
+import styled from 'styled-components';
 
 const meta = {
   title: 'Example/Badge/Champion',
@@ -19,9 +21,30 @@ const meta = {
 
 export default meta;
 
-export const Season10 = {
-  args: {
-    name: 'Garen',
-    lang: 'ko' as LanguageType,
-  },
+const Template = (args: ChampionBadge10Props) => {
+  return (
+    <Wrapper>
+      <ChampionBadge10 {...args} />
+      {/*아래는 툴팁의 컨텐츠가 다른 요소에 의해 가려지는지 테스트하기 위해서 추가한 컴포넌트*/}
+      <Mock />
+      <ChampionBadge10 name={'Senna'} lang={'ko'} />
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const Mock = styled.div`
+  width: 40px;
+  height: 40px;
+  background-color: antiquewhite;
+`;
+
+export const Season10: StoryFn<ChampionBadge10Props> = Template.bind({});
+Season10.args = {
+  name: 'Akali',
+  lang: 'ko',
 };

--- a/src/utils/components/Tooltip.tsx
+++ b/src/utils/components/Tooltip.tsx
@@ -9,7 +9,12 @@ type _TooltipProps = {
 
 export const Tooltip = ({ id, tooltipProps, children }: _TooltipProps) => {
   return (
-    <_Tooltip delayShow={0} delayHide={0} style={{ padding: '8px' }} {...tooltipProps} id={id}>
+    <_Tooltip
+      delayShow={0}
+      delayHide={0}
+      style={{ padding: '8px', zIndex: 9999 }}
+      {...tooltipProps}
+      id={id}>
       {children}
     </_Tooltip>
   );


### PR DESCRIPTION
As-is
<img width="385" alt="스크린샷 2023-11-18 오전 12 12 16" src="https://github.com/gaki2/tft-utils/assets/76833478/2ac17547-6479-4fe5-8cc2-944a98ff9307">



To-be

<img width="301" alt="스크린샷 2023-11-18 오전 12 28 36" src="https://github.com/gaki2/tft-utils/assets/76833478/4a264587-2bd0-43d9-b615-36430edf1226">